### PR TITLE
replace recursively

### DIFF
--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -26,7 +26,7 @@ class ThrottleMiddleware
      */
     public function __construct($config = [])
     {
-        $config += $this->_setConfiguration();
+        $config = array_replace_recursive($this->_setConfiguration(), $config);
         $this->setConfig($config);
     }
 


### PR DESCRIPTION
is not working recursively (docs suggest it's okay to only specify array keys that should be overwritten for response)

e.g. only body